### PR TITLE
🔓 Add N8N_SECURE_COOKIE to start command

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -34,7 +34,7 @@ export const EXPORT_FILENAME = "workflows.json";
 
 export const CLI_COMMANDS = {
   WATCH: "pnpm --filter n8n-nodes-base watch",
-  START: "N8N_DEV_RELOAD=true N8N_USER_MANAGEMENT_DISABLED=true pnpm start",
+  START: "N8N_DEV_RELOAD=true N8N_USER_MANAGEMENT_DISABLED=true N8N_SECURE_COOKIE=false pnpm start",
   EXPORT: `./packages/cli/bin/n8n export:workflow --all --pretty --output=./${EXPORT_FILENAME}`,
 };
 


### PR DESCRIPTION
Based on recent breaking changes, adding `N8N_SECURE_COOKIE=false` to the start command allows working in a local dev environment over unencrypted HTTP again.